### PR TITLE
Fix code scanning alert no. 70: Missing rate limiting

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -537,7 +537,12 @@ app.put('/update_settings',Parser.json(),(req,res) => {
     })
 })
 
-app.get('/get_alias',(req,res) => {
+const getAliasLimiter = RateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // limit each IP to 100 requests per windowMs
+});
+
+app.get('/get_alias', getAliasLimiter, (req,res) => {
     Authenticate(req,res,false,(mainUser,mainNetwork) => res.send(db.getAliasedUsers(mainUser,mainNetwork)))
 })
 


### PR DESCRIPTION
Fixes [https://github.com/MrFasolo97/ipfsVideoUploader/security/code-scanning/70](https://github.com/MrFasolo97/ipfsVideoUploader/security/code-scanning/70)

To fix the problem, we need to add rate limiting to the `/get_alias` route. This can be done by using the `express-rate-limit` package, which is already imported in the code. We will create a new rate limiter specifically for the `/get_alias` route and apply it to the route handler.

1. Define a new rate limiter for the `/get_alias` route.
2. Apply the rate limiter to the `/get_alias` route handler.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
